### PR TITLE
fix: add POSTGRES_HOST_AUTH_METHOD env var

### DIFF
--- a/bin/cmds/test_cmds/auto-compose.js
+++ b/bin/cmds/test_cmds/auto-compose.js
@@ -107,6 +107,9 @@ function postgres(compose, argv) {
   compose.services.postgres = merge({
     image: 'postgres:12-alpine',
     hostname: 'postgres',
+    environment: {
+      POSTGRES_HOST_AUTH_METHOD: 'trust',
+    },
   }, argv.extras.postgres);
 }
 


### PR DESCRIPTION
Postgres image starts failing with error:

```
Error: Database is uninitialized and superuser password is not specified.
       You must specify POSTGRES_PASSWORD to a non-empty value for the
       superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run".

       You may also use "POSTGRES_HOST_AUTH_METHOD=trust" to allow all
       connections without a password. This is *not* recommended.

       See PostgreSQL documentation about "trust":
       https://www.postgresql.org/docs/current/auth-trust.html
```

This happened in period between https://hub.docker.com/layers/postgres/library/postgres/latest/images/sha256-ff6a169fa199dcb8b217e8e70f68eec4068e596c7cbec7b646ea272b2872749a?context=explore and 5 weeeks before provided link.

I've decided to add the POSTGRES_HOST_AUTH_METHOD variable because Our services do not use any password in PostgreSQL connection in the test environment. If we will set the password for the database, We must update all services that will use PostgreSQL in tests with corresponding auth parameters.