### PR TITLE
feat: parsing Node.js version as a string

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -26,6 +26,7 @@ require('yargs')
     alias: 'n',
     describe: 'node version to use when building',
     default: '18',
+    type: 'string',
   })
   .option('env', {
     alias: 'E',


### PR DESCRIPTION
BREAKING CHANGE: Node.js version in .mdeprc should be a string.